### PR TITLE
Add search capability

### DIFF
--- a/usr/share/thingy/thingy.ui
+++ b/usr/share/thingy/thingy.ui
@@ -46,7 +46,16 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkSearchEntry" id="app_search">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="primary_icon_name">edit-find-symbolic</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="primary_icon_sensitive">False</property>
+          </object>
+          <packing>
+            <property name="position">2</property>
+          </packing>
         </child>
         <child>
           <placeholder/>


### PR DESCRIPTION
This pr introduces search capability for thingy, it searches globally without an `app_id`. 

While using `add_document_to_library` function i passed `app_id` as a null string. Please let me know if this should be change.
  
![image](https://user-images.githubusercontent.com/19881231/182023630-7c326a85-642c-44dc-a23e-52d4def59f01.png)
