### PR TITLE
Use auto resource management for license file

### DIFF
--- a/usr/lib/thingy/thingy.py
+++ b/usr/lib/thingy/thingy.py
@@ -167,12 +167,8 @@ class Window():
         dlg.set_program_name("thingy")
         dlg.set_comments(_("Library"))
         try:
-            h = open('/usr/share/common-licenses/GPL', encoding="utf-8")
-            s = h.readlines()
-            gpl = ""
-            for line in s:
-                gpl += line
-            h.close()
+            with open('/usr/share/common-licenses/GPL', encoding="utf-8") as h:
+                gpl = h.read()
             dlg.set_license(gpl)
         except Exception as e:
             print (e)


### PR DESCRIPTION
Replaced manual resource management for the license file with the `with` statement to ensure it always gets closed. Additionally, since concatenating the results of `readlines()` reconstructs the original file content, `read() `is used directly instead for simplicity and efficiency.